### PR TITLE
Allows modules that export through `exports`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ var proxyLoader = function(source)
 
 		// Global module exporters
 		var module = {exports: {}};
+		var exports = module.exports;
 
 		// A getter that can switch between CommonJS or AMD
 		var getResult = function()


### PR DESCRIPTION
Solves a problem with ES6 modules compiled with Babel and when people only export through `exports.smth`, instead of `module.exports = smth`.

For example, babel compiles ES6 modules like that:

```
function myModule() {
}

exports.default = myModule;
exports.__esModule = true;
```

Proxy loader didn't work with that form of export. This PR fixes it.
